### PR TITLE
add ability to listen to chat and fix something

### DIFF
--- a/maidroid/api.lua
+++ b/maidroid/api.lua
@@ -53,8 +53,8 @@ maidroid.maidroid = {}
 
 -- for the case, the luaentity is used as player
 function maidroid.maidroid.is_player(self)
-	if maidroid.maidroid.is_player_currently then
-		maidroid.maidroid.is_player_currently = false
+	if self.is_player_currently then
+		self.is_player_currently = false
 		return true
 	end
 	return false
@@ -620,6 +620,7 @@ function maidroid.register_maidroid(product_name, def)
 		pause                        = false,
 		manufacturing_number         = -1,
 		owner_name                   = "",
+		is_player_currently          = false,
 
 		-- callback methods.
 		on_activate                  = on_activate,

--- a/maidroid/script/instruction_set_doc.lua
+++ b/maidroid/script/instruction_set_doc.lua
@@ -18,6 +18,7 @@ local instr = {
 	{"place", "<s posname>[, <v errormsg>]", "Places a node, if posname is a variable, it is set to a bool indicating whether placing succeeded. If false, errormsg tells the reason."},
 	{"select_item", "<index>", "Swaps the currently wielded item with the item at place <index> in the main inventory."},
 	{"beep", "", "Execute this every second while the droid walks backwards, pls."},
+	{"listen_chat", "<s sayer>, <s message>", "Get the last thing that was written from a player into chat and the player's name."},
 }
 
 o = "Instructions:\n\n"

--- a/maidroid/script/instruction_set_doc.lua
+++ b/maidroid/script/instruction_set_doc.lua
@@ -18,7 +18,7 @@ local instr = {
 	{"place", "<s posname>[, <v errormsg>]", "Places a node, if posname is a variable, it is set to a bool indicating whether placing succeeded. If false, errormsg tells the reason."},
 	{"select_item", "<index>", "Swaps the currently wielded item with the item at place <index> in the main inventory."},
 	{"beep", "", "Execute this every second while the droid walks backwards, pls."},
-	{"listen_chat", "<s sayer>, <s message>", "Get the last thing that was written from a player into chat and the player's name."},
+	{"listen_chat", "<v sayer>, <v message>", "Get the last thing that was written from a player into chat and the player's name."},
 }
 
 o = "Instructions:\n\n"

--- a/maidroid_core/cores/ocr.lua
+++ b/maidroid_core/cores/ocr.lua
@@ -79,6 +79,11 @@ local function get_pt_under(pos, dir)
 	end
 end
 
+local chat_last_sayer, chat_last_message = "", ""
+minetest.register_on_chat_message(function(name, message)
+	chat_last_sayer, chat_last_message = name, message
+end)
+
 local maidroid_instruction_set = {
 	-- popular (similars in lua_api) information gathering functions
 	getpos = function(params, thread)
@@ -234,7 +239,7 @@ local maidroid_instruction_set = {
 		)
 		dp_pool[1].range = minetest.registered_items[""].range or 14
 		-- currently 1 possible tool
-		local wielded = obj:get_luaentity():get_wielded_item()
+		local wielded = thread.droid:get_wielded_item()
 		dp_pool[2] = minetest.get_dig_params(
 			groups,
 			wielded:get_tool_capabilities()
@@ -262,7 +267,7 @@ local maidroid_instruction_set = {
 			return true, false, "insufficient tool capabilities"
 		end
 
-		maidroid.maidroid.is_player_currently = true
+		thread.droid.is_player_currently = true
 		def.on_dig(pos, node, obj:get_luaentity())
 		--~ local success = minetest.dig_node(pos)
 
@@ -365,6 +370,10 @@ local maidroid_instruction_set = {
 	beep = function(_, thread)
 		minetest.sound_play("maidroid_beep", {pos = thread.droid.object:getpos()})
 		return true
+	end,
+
+	listen_chat = function()
+		return true, {chat_last_sayer, chat_last_message}
 	end,
 }
 


### PR DESCRIPTION
Siehe Dokumentation.

`is_player_currently` muss natürlich droidenabhängig sein, nicht global.

Man kann übrigens auch noch Nachrichten bekommen bevor der Maidroid an war, ich denke aber, das ist gut oder wenigstens tollerierbar so.

Leider funktioniert irgendwas beim `sleep` nicht, der Maidroid wacht nicht mehr auf.